### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.3
         ports:
         - containerPort: 80
 


### PR DESCRIPTION
## Policy Violation Remediation

The Kyverno policy 'disallow-latest-tag' prohibits the use of the 'latest' tag for container images in Deployments. The policy specifically checks for and rejects any container image with the ':latest' tag.

Changes made:
- Changed the nginx image tag from 'latest' to a specific version '1.25.3' to comply with the policy

Additional recommendations (not implemented):
- Consider adding resource limits and requests for the container
- Add security context configurations to enhance security posture
- Consider adding liveness and readiness probes for better container lifecycle management
- Add appropriate labels for better resource organization