### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,15 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.0
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
+          privileged: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - CHOWN


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to comply with the Kyverno policies:

1. Removed the AppArmor annotation that was set to 'unconfined' as it could be a security risk.
2. Replaced the hostPath volume with an emptyDir volume to comply with the 'disallow-host-path' policy.
3. Changed the image tag from 'latest' to a specific version '1.25.0' to comply with the 'disallow-latest-tag' policy.
4. Changed the hostPort from 80 to 0 to comply with the 'disallow-host-ports' policy.
5. Set privileged mode to false to comply with the 'disallow-privileged-containers' policy.
6. Replaced the SYS_ADMIN capability with CHOWN, which is in the allowed list according to the 'disallow-capabilities' policy.

Additional improvements that could be considered (but weren't implemented):
1. Adding resource limits and requests for the container
2. Setting a non-root user context
3. Adding security context at the pod level with runAsNonRoot: true
4. Adding network policies to restrict traffic