### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,16 +16,15 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.0
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
+          privileged: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - NET_BIND_SERVICE


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to comply with the Kyverno policies:

1. Removed the AppArmor annotation that was setting 'unconfined' mode.
2. Replaced the hostPath volume with an emptyDir volume to comply with the 'disallow-host-path' policy.
3. Changed the image tag from 'latest' to a specific version '1.25.0' to comply with the 'disallow-latest-tag' policy.
4. Changed the hostPort from 80 to 0 to comply with the 'disallow-host-ports' policy.
5. Set privileged mode to false to comply with the 'disallow-privileged-containers' policy.
6. Replaced the SYS_ADMIN capability with NET_BIND_SERVICE, which is in the allowed list according to the 'disallow-capabilities' policy.

Additional improvements that could be considered (but weren't implemented):
1. Adding a non-root user security context at the pod level
2. Setting additional security context parameters like readOnlyRootFilesystem: true
3. Adding resource limits and requests
4. Implementing network policies to restrict traffic