### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,16 +16,15 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.0
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
+          privileged: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - NET_BIND_SERVICE


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to comply with the Kyverno policies:

1. Removed the AppArmor annotation that was set to 'unconfined' as it's a security risk.
2. Changed the hostPath volume to an emptyDir volume to comply with the 'disallow-host-path' policy.
3. Changed the image tag from 'latest' to a specific version '1.25.0' to comply with the 'disallow-latest-tag' policy.
4. Changed the hostPort from 80 to 0 to comply with the 'disallow-host-ports' policy.
5. Set privileged to false to comply with the 'disallow-privileged-containers' policy.
6. Changed the SYS_ADMIN capability to NET_BIND_SERVICE which is in the allowed list of capabilities according to the 'disallow-capabilities' policy.

Additional improvements that could be made (but weren't required by the policies):
1. Consider adding a non-root user security context at the pod level.
2. Add resource limits and requests for the container.
3. Implement network policies to restrict traffic.
4. Consider using a read-only root filesystem.