### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -28,4 +28,4 @@ spec:
           privileged: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - AUDIT_WRITE


### PR DESCRIPTION
## Policy Violation Remediation

The Kyverno policy 'disallow-capabilities' restricts container capabilities to a specific allowed list. The original deployment had the 'SYS_ADMIN' capability which is not in the allowed list. I've replaced it with 'AUDIT_WRITE' which is one of the allowed capabilities. The allowed capabilities are: AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, and SYS_CHROOT. You could choose any of these allowed capabilities based on your application's requirements.