### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -18,16 +18,23 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to comply with the Kyverno policies:

1. Replaced the hostPath volume with an emptyDir volume to comply with the 'disallow-host-path' policy.
2. Changed the hostPort from 80 to 0 to comply with the 'disallow-host-ports' policy.
3. Set privileged to false to comply with the 'disallow-privileged-containers' policy.
4. Added allowPrivilegeEscalation: false to comply with the 'disallow-privilege-escalation' policy.
5. Modified capabilities to only add NET_BIND_SERVICE and drop ALL to comply with both 'disallow-capabilities' and 'disallow-capabilities-strict' policies.
6. Added seccompProfile with type: RuntimeDefault to comply with the 'restrict-seccomp-strict' policy.
7. Added pod-level securityContext with runAsNonRoot: true and runAsUser: 1000 to comply with the 'require-run-as-nonroot' policy.

Additional improvements that could be made (but weren't required by the policies):
1. Use a specific image tag instead of 'latest' for better stability and security.
2. Consider adding resource limits and requests to prevent resource exhaustion.