### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -18,16 +18,23 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
           capabilities:
             add:
-            - SYS_ADMIN
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Replaced the hostPath volume with an emptyDir volume to comply with 'disallow-host-path' policy.
2. Changed hostPort from 80 to 0 to comply with 'disallow-host-ports' policy.
3. Set privileged: false to comply with 'disallow-privileged-containers' policy.
4. Added allowPrivilegeEscalation: false to comply with 'disallow-privilege-escalation' policy.
5. Modified capabilities to only add NET_BIND_SERVICE and drop ALL to comply with 'disallow-capabilities-strict' policy.
6. Added seccompProfile with type: RuntimeDefault to comply with 'restrict-seccomp-strict' policy.
7. Added pod-level securityContext with runAsNonRoot: true and runAsUser: 1000 to comply with 'require-run-as-nonroot' policy.

Additional improvements that could be considered (but not implemented):
- Use a specific version tag for the nginx image instead of 'latest' for better stability and security.
- Consider using a non-root container image if available.
- Add resource limits and requests to prevent resource exhaustion.