### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,19 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Remediated policy violation: disallow-capabilities
2. Remediated policy violation: disallow-capabilities-strict
3. Remediated policy violation: disallow-capabilities-strict
4. Remediated policy violation: disallow-host-path
5. Remediated policy violation: disallow-host-ports
6. Remediated policy violation: disallow-privilege-escalation
7. Remediated policy violation: disallow-privileged-containers
8. Remediated policy violation: require-run-as-nonroot
9. Remediated policy violation: restrict-seccomp-strict
10. Remediated policy violation: restrict-volume-types

Successfully remediated 10 policy violations in total.