### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -16,18 +14,16 @@ spec:
       labels:
         app: nginx
     spec:
-      volumes:
-      - name: host-vol
-        hostPath:
-          path: /etc
+      volumes: []
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that was set to 'unconfined'
2. Removed the hostPath volume as it violates the disallow-host-path policy
3. Removed the hostPort configuration as it violates the disallow-host-ports policy
4. Fixed security context violations by:
   - Setting privileged: false (disallow-privileged-containers)
   - Removing capabilities (disallow-capabilities-strict)
   - Adding runAsNonRoot: true and runAsUser: 1000 (require-run-as-nonroot)
   - Adding allowPrivilegeEscalation: false (disallow-privilege-escalation)
   - Adding seccompProfile with type: RuntimeDefault (restrict-seccomp-strict)

Additional improvement suggestions (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest'
- Add resource limits and requests for the container
- Consider adding network policies to restrict traffic
- Add liveness and readiness probes for better container lifecycle management