### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,13 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
+          hostPort: 0
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false
+          capabilities: {}


### PR DESCRIPTION
## Policy Violation Remediation

The following violations were remediated:

1. Removed the AppArmor annotation that was set to 'unconfined' as it's a security risk.
2. Replaced the hostPath volume with an emptyDir volume to comply with the 'disallow-host-path' policy.
3. Changed the hostPort from 80 to 0 to comply with the 'disallow-host-ports' policy.
4. Set privileged: false to comply with the 'disallow-privileged-containers' policy.
5. Removed the SYS_ADMIN capability which violates the 'disallow-capabilities' policy that only allows specific capabilities.

Additional recommendations (not implemented):
- Consider using a specific image tag instead of 'latest' for better version control and security.
- Add resource limits and requests to prevent resource exhaustion.
- Consider adding securityContext at the pod level with runAsNonRoot: true for better security posture.