### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,18 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Removed the unconfined AppArmor annotation which violates security best practices
2. Replaced the hostPath volume with an emptyDir volume to comply with disallow-host-path policy
3. Removed the hostPort specification to comply with disallow-host-ports policy
4. Modified the securityContext to:
   - Set privileged: false (disallow-privileged-containers)
   - Add runAsNonRoot: true and runAsUser: 1000 (require-run-as-nonroot)
   - Add allowPrivilegeEscalation: false (disallow-privilege-escalation)
   - Remove SYS_ADMIN capability and drop ALL capabilities (disallow-capabilities-strict)
   - Add seccompProfile with type: RuntimeDefault (restrict-seccomp-strict)

Additional improvement suggestions (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest'
- Add resource limits and requests for the container
- Consider adding network policies to restrict traffic