### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,16 +16,11 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false


### PR DESCRIPTION
## Policy Violation Remediation

I've made the following changes to remediate policy violations:

1. Removed the AppArmor annotation that was setting the profile to 'unconfined', which is a security risk.

2. Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy. This prevents the pod from accessing sensitive host filesystem paths.

3. Removed the hostPort specification to comply with the disallow-host-ports policy. Using hostPorts can cause port conflicts and expose services directly on the host network.

4. Set privileged: false and removed the SYS_ADMIN capability to comply with the disallow-privileged-containers and disallow-capabilities policies. Privileged containers and excessive capabilities pose significant security risks.

Additional recommendations (not implemented):
- Consider using a specific version tag instead of 'latest' for the nginx image
- Add resource limits and requests
- Add a non-root user security context
- Consider adding network policies to restrict traffic