### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,16 +16,11 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that was setting the profile to 'unconfined', which is a security risk.
2. Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy.
3. Removed the hostPort specification to comply with the disallow-host-ports policy.
4. Set privileged: false and removed the SYS_ADMIN capability to comply with the disallow-privileged-containers and disallow-capabilities policies.

Additional recommendations (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest'
- Add resource limits and requests for the container
- Consider adding securityContext.runAsNonRoot: true and a specific runAsUser
- Add readiness and liveness probes for better container lifecycle management