### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         emptyDir: {}
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.3
         ports:
         - containerPort: 80
         securityContext:


### PR DESCRIPTION
## Policy Violation Remediation

**File:** apps/nginx/deployment.yaml
**Explanation:** I've made the following changes to remediate policy violations:

1. Removed the AppArmor annotation that was setting 'unconfined' profile
2. Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy
3. Removed the hostPort specification to comply with the disallow-host-ports policy
4. Set privileged: false and removed the SYS_ADMIN capability to comply with the disallow-privileged-containers and disallow-capabilities policies

Additional recommendations (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest'
- Add resource limits and requests for the container
- Consider adding securityContext.runAsNonRoot: true and a specific runAsUser
- Add readiness and liveness probes for better container lifecycle management

**Updated:** 2025-08-15 09:42:38
**File:** apps/nginx/deployment.yaml
**Explanation:** The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that was setting 'unconfined' profile
2. Changed the hostPath volume to an emptyDir to comply with disallow-host-path policy
3. Changed the image from 'nginx:latest' to a specific version 'nginx:1.25.3' to avoid using floating tags
4. Removed the hostPort specification to comply with disallow-host-ports policy
5. Set privileged: false and removed the SYS_ADMIN capability to comply with disallow-privileged-containers and disallow-capabilities policies

Additional recommendations (not implemented):
- Consider adding resource limits and requests for the container
- Add security context settings like runAsNonRoot: true and readOnlyRootFilesystem: true
- Consider adding network policies to restrict traffic
- Add liveness and readiness probes for better container health monitoring