### PR TITLE
fix: Policy violation remediation

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,11 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false


### PR DESCRIPTION
## Policy Violation Remediation

The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that was set to 'unconfined', which is a security risk.
2. Replaced the hostPath volume with an emptyDir volume to comply with the disallow-host-path policy.
3. Removed the hostPort specification to comply with the disallow-host-ports policy.
4. Set privileged: false and removed the SYS_ADMIN capability to comply with the disallow-privileged-containers and disallow-capabilities policies.

Additional recommendations (not implemented):
- Consider using a specific version tag for the nginx image instead of 'latest' for better stability and security.
- Add resource limits and requests to ensure proper resource allocation.
- Consider adding securityContext.runAsNonRoot: true and specifying a non-zero user ID.
- Add network policies to restrict traffic to and from the pod.