### PR TITLE
fix: Policy violation remediation in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -18,16 +16,11 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.3
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false


### PR DESCRIPTION
## Policy Violation Remediation

**File:** apps/nginx/deployment.yaml
**Explanation:** The following changes were made to remediate policy violations:

1. Removed the AppArmor annotation that was setting 'unconfined' profile
2. Changed the hostPath volume to an emptyDir volume to comply with disallow-host-path policy
3. Changed the image from 'nginx:latest' to a specific version 'nginx:1.25.3' to avoid using the 'latest' tag
4. Removed the hostPort specification to comply with disallow-host-ports policy
5. Set privileged: false and removed the SYS_ADMIN capability to comply with disallow-privileged-containers and disallow-capabilities policies

Additional recommendations (not implemented):
- Consider adding resource limits and requests for the container
- Add a non-root user security context
- Consider adding network policies to restrict traffic
- Add liveness and readiness probes for better container health monitoring