### PR TITLE
fix: Policy violation remediation in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
 spec:
   replicas: 1
   selector:
@@ -16,18 +14,10 @@ spec:
       labels:
         app: nginx
     spec:
-      volumes:
-      - name: host-vol
-        hostPath:
-          path: /etc
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+          privileged: false


### PR DESCRIPTION
## Policy Violation Remediation

**File:** apps/nginx/deployment.yaml
**Explanation:** The following violations were remediated:

1. Removed the AppArmor annotation that was set to 'unconfined', which is a security risk.
2. Removed the hostPath volume that was mounting /etc, which violates the disallow-host-path policy.
3. Removed the hostPort: 80 configuration, which violates the disallow-host-ports policy.
4. Set privileged: false and removed the SYS_ADMIN capability, which violates the disallow-privileged-containers and disallow-capabilities policies.

Additional recommendations (not implemented):
1. Use a specific image tag instead of 'latest' for better version control and security.
2. Consider adding resource limits and requests for the container.
3. Add securityContext.runAsNonRoot: true to ensure the container runs as a non-root user.
4. Consider adding network policies to restrict traffic to/from the pod.