### PR TITLE
fix: Policy violation remediation in nginx-chart/templates/deployment.yaml

### DIFF
--- a/nginx-chart/templates/deployment.yaml
+++ b/nginx-chart/templates/deployment.yaml
@@ -18,33 +18,18 @@ spec:
       labels:
         {{- include "nginx-chart.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.volumes.hostPath.enabled }}
-      volumes:
-      - name: {{ .Values.volumes.hostPath.name }}
-        hostPath:
-          path: {{ .Values.volumes.hostPath.path }}
-        emptyDir: {}
-      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.containerPort }}
-          {{- if .Values.hostPort }}
-          hostPort: 0
-          {{- end }}
         securityContext:
-          privileged: {{ .Values.securityContext.privileged }}
+          privileged: false
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
           {{- end }}
-        {{- if .Values.volumes.hostPath.enabled }}
-        volumeMounts:
-        - name: {{ .Values.volumes.hostPath.name }}
-          mountPath: /mnt/host-vol
-        {{- end }}
         {{- with .Values.resources }}
         resources:
           {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
## Policy Violation Remediation

**File:** nginx-chart/templates/deployment.yaml
**Explanation:** The changes address multiple policy violations in the Deployment:

1. Removed hostPath volume configuration to comply with the 'disallow-host-path' policy. HostPath volumes are security risks as they allow access to the host filesystem.

2. Removed hostPort configuration from container ports to comply with the 'disallow-host-ports' policy. Host ports can lead to network traffic snooping and port conflicts.

3. Set 'privileged: false' explicitly in the container's securityContext to comply with the 'disallow-privileged-containers' policy. Privileged containers have nearly unrestricted host access.

4. Removed the volumeMounts for the hostPath volume since the volume itself was removed.

No changes were needed for the 'disallow-capabilities' policy as there are no non-allowed capabilities being added in the deployment. If capabilities need to be added in the future, they must be limited to the allowed list: AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT.

### Authentication
This PR was created using PAT authentication.