### PR TITLE
fix: Policy violation remediation in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
   annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+    {}
 spec:
   replicas: 1
   selector:
@@ -17,17 +17,19 @@ spec:
         app: nginx
     spec:
       volumes:
-      - name: host-vol
-        hostPath:
-          path: /etc
+      []
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop: ["ALL"]


### PR DESCRIPTION
## Policy Violation Remediation

**File:** apps/nginx/deployment.yaml
**Explanation:** I've fixed all policy violations by implementing the following changes:

1. Removed the AppArmor annotation by replacing it with an empty object
2. Removed hostPath volume which violates the 'disallow-host-path' policy
3. Added pod-level securityContext with runAsNonRoot: true, runAsUser: 1000, and seccompProfile.type: RuntimeDefault to comply with 'require-run-as-nonroot' and 'restrict-seccomp-strict'
4. Removed the hostPort setting which violates 'disallow-host-ports'
5. Changed privileged: true to false to comply with 'disallow-privileged-containers'
6. Added allowPrivilegeEscalation: false to comply with 'disallow-privilege-escalation'
7. Replaced capabilities.add: ["SYS_ADMIN"] with capabilities.drop: ["ALL"] to comply with both 'disallow-capabilities' policies

The CUDL patch is now valid with correct context lines and sequential ordering that properly match the target resource.

### Authentication
This PR was created using PAT authentication.