### PR TITLE
fix: Policy violation remediation in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -4,8 +4,7 @@ metadata:
   name: nginx
   labels:
     app: nginx
-  annotations:
-    container.apparmor.security.beta.kubernetes.io/nginx: unconfined
+  annotations: {}
 spec:
   replicas: 1
   selector:
@@ -18,16 +17,19 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         securityContext:
-          privileged: true
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**File:** apps/nginx/deployment.yaml
**Explanation:** I made the following changes to remediate policy violations:

1. Removed the unconfined AppArmor annotation as it violates security policies
2. Replaced hostPath volume with emptyDir to comply with disallow-host-path policy
3. Removed hostPort from container port specification to comply with disallow-host-ports policy
4. Modified securityContext to:
   - Set privileged: false (disallow-privileged-containers)
   - Add runAsNonRoot: true and runAsUser: 1000 (require-run-as-nonroot)
   - Add allowPrivilegeEscalation: false (disallow-privilege-escalation)
   - Add seccompProfile with type RuntimeDefault (restrict-seccomp-strict)
   - Replace capabilities.add with capabilities.drop[ALL] to remove all capabilities (disallow-capabilities-strict)

Additional improvement suggestion (not implemented): Consider adding resource limits and requests to comply with resource management best practices, but this wasn't explicitly required by the policies.

### Authentication
This PR was created using PAT authentication.