### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,19 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +37,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| require-run-as-nonroot | Added runAsNonRoot: true at pod and container levels to enforce non-root execution | Application will run as non-root user; if the container image expects to run as root or doesn't handle non-root execution, it may fail to start | high |
| disallow-host-path | Replaced hostPath volume with emptyDir to eliminate host filesystem access | Application will lose access to host /etc directory; if the app depends on host system configuration files, it will fail to start | low |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to prevent automatic mounting of service account tokens | Application will lose access to Kubernetes API via mounted service account; if the app uses Kubernetes client libraries, it may fail | high |
| restrict-volume-types | Changed hostPath volume to emptyDir which is an allowed volume type | Application will use temporary storage instead of host filesystem; data persistence and host file access will be lost | low |
| disallow-capabilities | Removed SYS_ADMIN capability as it's not in the allowed capabilities list | Application will lose SYS_ADMIN privileges; if the app requires system administration capabilities, it will fail to function properly | low |
| disallow-host-ports | Removed hostPort: 80 configuration to prevent direct host port binding | Application will no longer be accessible directly on host port 80; requires Service or Ingress for external access | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to prevent privilege escalation | Application cannot escalate privileges during runtime; most applications work normally unless they specifically need privilege escalation | high |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added required 'drop: [ALL]' to capabilities configuration | Application will lose SYS_ADMIN privileges; if the app requires system administration capabilities, it will fail to function properly | low |
| restrict-seccomp-strict | Added seccompProfile with type: RuntimeDefault at pod and container levels | Application will run with default seccomp restrictions; system calls may be limited but most applications work normally | high |
| disallow-privileged-containers | Changed privileged: true to privileged: false to disable privileged mode | Application will lose privileged access to host resources; if the app requires privileged operations, it will fail to function | low |
