### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        seccompProfile:
+          type: {{ .Values.securityContext.seccompProfile.type }}
       {{- if .Values.volumes.hostPath.enabled }}
       volumes:
       - name: {{ .Values.volumes.hostPath.name }}
@@ -35,6 +40,10 @@ spec:
           {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          seccompProfile:
+            type: {{ .Values.securityContext.seccompProfile.type }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,25 +21,31 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
+hostPort: 0
 
 # Volume configuration
 volumes:
   hostPath:
-    enabled: true
-    path: /etc
+    enabled: false
+    path: ""
     name: host-vol
 
 # Pod annotations
-podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+podAnnotations: {}
+
+# Security settings
+automountServiceAccountToken: false
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| require-run-as-nonroot | Set runAsNonRoot to true in values.yaml and added fields to both pod and container security contexts in template | Pod and containers will run as non-root user, may fail if application requires root privileges | low |
| restrict-apparmor-profiles | Removed insecure unconfined AppArmor annotation from podAnnotations in values.yaml | Default AppArmor profile will be used instead of unconfined | high |
| restrict-volume-types | Disabled hostPath volume by setting enabled to false in values.yaml | Application will lose access to host filesystem at /etc, may fail if host access is required | low |
| disallow-host-path | Disabled hostPath volume by setting enabled to false in values.yaml | Same as restrict-volume-types - loses host filesystem access | low |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault to values.yaml and template for both pod and container contexts | Default seccomp profile applied, may block certain system calls if application needs them | high |
| disallow-capabilities-strict | Changed capabilities to drop ALL instead of adding SYS_ADMIN in values.yaml | All capabilities dropped, container runs with minimal privileges | low |
| disallow-capabilities | Removed SYS_ADMIN from capabilities.add and added ALL to capabilities.drop in values.yaml | Container loses elevated system capabilities, may fail if admin privileges are needed | low |
| disallow-host-ports | Changed hostPort from 81 to 0 in values.yaml | Service will not bind to host port 81, external access may require different configuration | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to values.yaml and template | Pod cannot access Kubernetes API using service account token, may fail if API access is required | high |
| disallow-privilege-escalation | Set allowPrivilegeEscalation to false in values.yaml and added field to template | Container will not be able to gain additional privileges during execution | high |
| disallow-privileged-containers | Changed privileged from true to false in values.yaml | Container loses privileged access to host resources, may fail if privileged operations are needed | low |
