### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,20 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +38,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-ports | Removed hostPort: 80 from container port configuration | Application will no longer bind directly to host port 80; external access requires a Service or Ingress resource | high |
| restrict-seccomp-strict | Added seccompProfile with type: RuntimeDefault to both pod and container security contexts | Container uses default seccomp profile restricting system calls; minimal impact for standard nginx operations | high |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added drop: ALL to meet strict capability requirements | Container drops all Linux capabilities; standard nginx functionality should work, but any capability-dependent features will fail | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec | Pod cannot access Kubernetes API using default service account; minimal impact unless application needs API access | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Container cannot escalate privileges during runtime; minimal impact for standard nginx operations | high |
| disallow-host-path | Replaced hostPath volume with emptyDir to eliminate host filesystem access | Volume no longer accesses host /etc directory; if application depends on host configuration files, it will fail to start | low |
| disallow-privileged-containers | Removed privileged: true from container security context | Container loses access to all host devices and kernel capabilities; nginx should operate normally in unprivileged mode | high |
| restrict-volume-types | Changed hostPath volume to emptyDir volume type to use only allowed volume types | Volume no longer provides persistent host directory access; data will be ephemeral and lost on pod restart | low |
| disallow-capabilities | Removed prohibited SYS_ADMIN capability from container security context | Application will lose SYS_ADMIN privileges; if the nginx container requires system administration capabilities, it will fail to perform those operations | low |
| require-run-as-nonroot | Added runAsNonRoot: true and runAsUser: 1000 to both pod and container security contexts | Container runs as user 1000 instead of root; nginx may need configuration changes for non-root operation (ports, file permissions) | low |
