### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,11 +18,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        seccompProfile:
+          type: {{ .Values.securityContext.seccompProfile.type }}
       {{- if .Values.volumes.hostPath.enabled }}
       volumes:
       - name: {{ .Values.volumes.hostPath.name }}
-        hostPath:
-          path: {{ .Values.volumes.hostPath.path }}
+        emptyDir: {}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -30,11 +34,12 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.containerPort }}
-          {{- if .Values.hostPort }}
-          hostPort: {{ .Values.hostPort }}
-          {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          seccompProfile:
+            type: {{ .Values.securityContext.seccompProfile.type }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
@@ -42,6 +47,15 @@ spec:
         {{- if .Values.volumes.hostPath.enabled }}
         volumeMounts:
         - name: {{ .Values.volumes.hostPath.name }}
+          mountPath: /mnt/host-vol
+        {{- if .Values.volumes.emptyDir.enabled }}
+        volumeMounts:
+        - name: {{ .Values.volumes.emptyDir.name }}
+          mountPath: /mnt/host-vol
+        {{- end }}
+        {{- else if .Values.volumes.emptyDir.enabled }}
+        volumeMounts:
+        - name: {{ .Values.volumes.emptyDir.name }}
           mountPath: /mnt/host-vol
         {{- end }}
         {{- with .Values.resources }}

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,25 +21,29 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
 
 # Volume configuration
 volumes:
   hostPath:
+    enabled: false
+  emptyDir:
     enabled: true
-    path: /etc
     name: host-vol
 
 # Pod annotations
 podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+  container.apparmor.security.beta.kubernetes.io/nginx-chart: runtime/default
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| restrict-volume-types | Changed from hostPath to emptyDir which is in allowed list | Volume storage will be ephemeral instead of persistent host path | low |
| disallow-host-path | Disabled hostPath volume and replaced with emptyDir volume | Volume will be ephemeral instead of accessing host filesystem | low |
| disallow-privileged-containers | Set privileged to false in security context | Container will not run in privileged mode, may break functionality requiring host access | low |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec | Pod will not have access to Kubernetes API via service account token | high |
| disallow-capabilities | Removed SYS_ADMIN capability and added drop ALL | Container capabilities severely restricted | low |
| disallow-host-ports | Removed hostPort configuration | Service will not be accessible on host port 81 | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Container cannot escalate privileges | high |
| require-run-as-nonroot | Added runAsNonRoot: true to pod and container security contexts | Container must run as non-root user, may require image changes | low |
| restrict-seccomp-strict | Added seccomp profile with RuntimeDefault type | Seccomp will filter system calls according to default profile | high |
| restrict-apparmor-profiles | Changed AppArmor annotation from unconfined to runtime/default | AppArmor will enforce default security profile | high |
| disallow-capabilities-strict | Changed capabilities to drop ALL instead of adding SYS_ADMIN | Container will run with minimal capabilities, may break functionality requiring elevated permissions | low |
