### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,6 +18,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        seccompProfile:
+          type: {{ .Values.securityContext.seccompProfile.type }}
       {{- if .Values.volumes.hostPath.enabled }}
       volumes:
       - name: {{ .Values.volumes.hostPath.name }}
@@ -35,9 +40,16 @@ spec:
           {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          seccompProfile:
+            type: {{ .Values.securityContext.seccompProfile.type }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
-            {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
+            drop:
+              {{- range .Values.securityContext.capabilities.drop }}
+              - {{ . }}
+              {{- end }}
           {{- end }}
         {{- if .Values.volumes.hostPath.enabled }}
         volumeMounts:

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,25 +21,31 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
+hostPort: 0
 
 # Volume configuration
 volumes:
   hostPath:
-    enabled: true
-    path: /etc
-    name: host-vol
+    enabled: false
+    path: ""
+    name: ""
 
 # Pod annotations
-podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+podAnnotations: {}
+
+# Security settings
+automountServiceAccountToken: false
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-ports | Changed hostPort from 81 to 0 in values.yaml to disable host port binding | Service will not bind to host port, external access must go through Kubernetes service | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context in values.yaml and template | Container cannot escalate privileges, may break applications that need to change user/group | high |
| require-run-as-nonroot | Added runAsNonRoot: true to both pod-level and container-level security context in values.yaml and template | Container will run as non-root user, may fail if application expects root privileges | high |
| restrict-apparmor-profiles | Removed unconfined AppArmor annotation from podAnnotations in values.yaml | Default AppArmor profile will be applied instead of unconfined, may restrict container behavior | high |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault to security context in values.yaml and template | Applies default seccomp filter, may block some system calls the application uses | high |
| disallow-privileged-containers | Changed privileged from true to false in values.yaml securityContext | Container loses privileged access to host, may break functionality requiring privileged mode | high |
| restrict-volume-types | Disabled hostPath volume by setting enabled to false in values.yaml volumes configuration | Host filesystem will not be mounted, may break functionality requiring host access | high |
| disallow-capabilities | Removed SYS_ADMIN capability from add list, now using empty array in values.yaml | Container loses SYS_ADMIN capability, may break advanced system operations | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to values.yaml and template spec | Pod cannot access Kubernetes API using service account, may break applications using K8s API | high |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added drop: [ALL] to capabilities configuration in values.yaml | Container loses all Linux capabilities, may break functionality requiring specific capabilities | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a PR that fixes multiple policy violations into separate PRs, one for each specified policy.

</details>