### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
       volumes:
       - name: host-vol
         hostPath:
@@ -34,7 +35,7 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
           capabilities:
             add:
             - SYS_ADMIN


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| restrict-automount-sa-token | Added automountServiceAccountToken: false to prevent automatic mounting of service account tokens in the pod spec. | Application will no longer have access to Kubernetes API via mounted service account token; if the app uses Kubernetes client libraries or kubectl commands, it will fail authentication. | low |
| disallow-privileged-containers | Changed privileged: true to privileged: false in the nginx container's security context to disable privileged mode. | Container loses root-level host access and advanced capabilities; if the app requires kernel modules, direct hardware access, or privileged operations, it may fail to function properly. | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a PR that fixes multiple policy violations into separate PRs, one for each specified policy.

</details>