### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -33,7 +33,7 @@ hostPort: 81
 # Volume configuration
 volumes:
   hostPath:
-    enabled: true
+    enabled: false
     path: /etc
     name: host-vol
 


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-path | Disabled hostPath volumes by setting volumes.hostPath.enabled to false in values.yaml | The container will no longer have access to the host filesystem at /etc, and the volume mount at /mnt/host-vol will be removed | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a PR that fixes multiple policy violations into separate PRs, one for each specified policy.

</details>