### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,6 +18,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.podSecurityContext.automountServiceAccountToken }}
+      securityContext:
+        runAsNonRoot: {{ .Values.podSecurityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        seccompProfile:
+          type: {{ .Values.podSecurityContext.seccompProfile.type }}
       {{- if .Values.volumes.hostPath.enabled }}
       volumes:
       - name: {{ .Values.volumes.hostPath.name }}
@@ -35,6 +41,11 @@ spec:
           {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          seccompProfile:
+            type: {{ .Values.securityContext.seccompProfile.type }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,25 +21,37 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
+hostPort: 0
 
 # Volume configuration
 volumes:
   hostPath:
-    enabled: true
-    path: /etc
-    name: host-vol
+    enabled: false
+    path: ""
+    name: ""
 
 # Pod annotations
-podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+podAnnotations: {}
+
+# Pod security settings
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  seccompProfile:
+    type: RuntimeDefault
+  automountServiceAccountToken: false
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault to both pod and container security contexts | System calls are restricted by default seccomp profile | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec in values.yaml and template | Pod cannot access Kubernetes API via service account token | high |
| disallow-capabilities-strict | Changed capabilities to drop ALL instead of adding SYS_ADMIN | All Linux capabilities are dropped from container | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context in values.yaml | Containers cannot escalate privileges during runtime | high |
| restrict-volume-types | Disabled hostPath volumes by setting enabled: false in values.yaml | Pod no longer mounts host filesystem paths | high |
| disallow-capabilities | Removed SYS_ADMIN from capabilities.add in values.yaml | Container loses administrative capabilities | high |
| disallow-host-path | Disabled hostPath volumes by setting enabled: false in values.yaml | Pod cannot access host filesystem | high |
| disallow-privileged-containers | Changed privileged: true to privileged: false in values.yaml | Container loses privileged access to host resources | high |
| disallow-host-ports | Changed hostPort from 81 to 0 in values.yaml | Container port not exposed on host network interface | high |
| restrict-apparmor-profiles | Removed insecure AppArmor annotation from podAnnotations in values.yaml | Default AppArmor profile will be used instead of unconfined | high |
| require-run-as-nonroot | Added runAsNonRoot: true and runAsUser: 1000 to both pod and container security contexts | Application runs as non-root user (UID 1000) | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>