### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,20 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +38,10 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-ports | Removed hostPort: 80 to prevent binding to host network port | Application will no longer be directly accessible via host port 80; requires LoadBalancer or NodePort service for external access. Networking configuration needs to be updated. | low |
| disallow-capabilities | Removed SYS_ADMIN capability which is not in the allowed capabilities list | Application will lose SYS_ADMIN privileges; if the app requires system administration functions, it will fail. Verify the app doesn't need admin capabilities before applying. | low |
| disallow-privileged-containers | Removed privileged: true to disable privileged container mode | Application will lose privileged access to host resources; if the app requires device access or low-level system operations, it will fail. Verify the app doesn't need privileged mode before applying. | low |
| require-run-as-nonroot | Added runAsNonRoot: true to both pod and container securityContext to ensure non-root execution | Application will run as non-root user (UID 1000); if the app expects to run as root or access root-only resources, it will fail. Verify the app supports non-root execution before applying. | low |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added drop: ALL to meet strict capability requirements | Application will lose all Linux capabilities; if the app requires any privileged operations, it will fail. Verify the app runs with minimal privileges before applying. | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container securityContext to prevent privilege escalation | Application cannot escalate privileges during runtime; most standard applications are unaffected, but verify if the app uses setuid/setgid binaries. | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to prevent automatic mounting of service account tokens | Application will lose access to Kubernetes API; if the app uses kubectl or Kubernetes client libraries, it will fail. Verify the app doesn't need API access before applying. | low |
| restrict-volume-types | Replaced hostPath volume type with allowed emptyDir volume type | Application will lose access to host /etc directory; if the app depends on files in /etc, it will fail to start. Verify the app doesn't need host filesystem access before applying. | low |
| restrict-seccomp-strict | Added seccompProfile with type: RuntimeDefault to both pod and container securityContext | Application will use default seccomp profile restricting certain system calls; most applications are unaffected, but verify if the app uses restricted syscalls. | high |
| disallow-host-path | Replaced hostPath volume with emptyDir to prevent host filesystem access | Application will lose access to host /etc directory; if the app depends on files in /etc, it will fail to start. Verify the app doesn't need host filesystem access before applying. | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>