### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,19 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +37,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-ports | Removed hostPort: 80 from containerPort 80 to prevent binding to host network interface | Application will no longer be directly accessible via host port 80; requires Service or Ingress for external access. Update networking configuration accordingly. | high |
| disallow-privileged-containers | Changed privileged: true to privileged: false to disable privileged mode | Container loses all privileged access including raw device access and kernel capabilities; will break apps requiring privileged operations. | low |
| restrict-seccomp-strict | Added seccompProfile with type: RuntimeDefault to both pod and container securityContext | Container will use default seccomp filtering; may block system calls needed by some applications, causing runtime failures. | high |
| restrict-volume-types | Changed hostPath volume to emptyDir which is an allowed volume type under restricted policy | Application will lose access to host /etc directory; if the app depends on files in /etc, it will fail to start. Verify the app doesn't need host filesystem access before applying. | low |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added drop: [ALL] to meet strict capability requirements | Container loses SYS_ADMIN capability and all other capabilities; will break apps requiring administrative privileges or specific capabilities. | low |
| require-run-as-nonroot | Added runAsNonRoot: true to both pod and container securityContext to enforce non-root execution | Container must run as non-root user; will fail if image defaults to root or app requires root privileges. Verify image supports non-root execution. | high |
| disallow-capabilities | Removed SYS_ADMIN capability as it's not in the baseline allowed list | Container loses SYS_ADMIN capability; will break apps requiring administrative privileges like mounting filesystems or managing system resources. | low |
| disallow-host-path | Replaced hostPath volume 'host-vol' with emptyDir to prevent access to host filesystem | Application will lose access to host /etc directory; if the app depends on files in /etc, it will fail to start. Verify the app doesn't need host filesystem access before applying. | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container securityContext to prevent privilege escalation | Container cannot escalate privileges during runtime; may affect apps that need to change user permissions or access privileged operations. | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec to disable automatic service account token mounting | Pod cannot access Kubernetes API using default service account; will break apps that need to interact with K8s API. Add explicit RBAC if API access needed. | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>