### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,11 +18,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if .Values.volumes.hostPath.enabled }}
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        seccompProfile:
+          type: {{ .Values.securityContext.seccompProfile.type }}
+      {{- if .Values.volumes.emptyDir.enabled }}
       volumes:
-      - name: {{ .Values.volumes.hostPath.name }}
-        hostPath:
-          path: {{ .Values.volumes.hostPath.path }}
+      - name: {{ .Values.volumes.emptyDir.name }}
+        emptyDir: {}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -35,14 +39,18 @@ spec:
           {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          seccompProfile:
+            type: {{ .Values.securityContext.seccompProfile.type }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
           {{- end }}
-        {{- if .Values.volumes.hostPath.enabled }}
+        {{- if .Values.volumes.emptyDir.enabled }}
         volumeMounts:
-        - name: {{ .Values.volumes.hostPath.name }}
-          mountPath: /mnt/host-vol
+        - name: {{ .Values.volumes.emptyDir.name }}
+          mountPath: /mnt/empty-vol
         {{- end }}
         {{- with .Values.resources }}
         resources:

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,25 +21,28 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
+hostPort: 0
 
 # Volume configuration
 volumes:
-  hostPath:
+  emptyDir:
     enabled: true
-    path: /etc
-    name: host-vol
+    name: empty-vol
 
 # Pod annotations
 podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+  container.apparmor.security.beta.kubernetes.io/nginx-chart: runtime/default
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| require-run-as-nonroot | Added runAsNonRoot: true at both pod and container level | Container must run as non-root user, may fail if image requires root | low |
| restrict-apparmor-profiles | Changed AppArmor profile from unconfined to runtime/default | Container runs with default AppArmor restrictions | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec | Pod cannot access Kubernetes API using service account token | high |
| disallow-privileged-containers | Changed privileged: true to privileged: false | Container runs without privileged access, may break functionality | low |
| disallow-capabilities-strict | Changed capabilities to drop ALL instead of adding SYS_ADMIN | Container loses SYS_ADMIN capability, may break functionality requiring elevated privileges | low |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault at pod and container level | Container runs with default seccomp restrictions | high |
| disallow-host-path | Replaced hostPath volume with emptyDir | Cannot access host /etc directory, data is ephemeral | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Container cannot escalate privileges during runtime | high |
| disallow-host-ports | Set hostPort to 0 to disable host port binding | Application no longer accessible via host port, only through service | high |
| restrict-volume-types | Replaced hostPath volume with emptyDir volume | Volume is ephemeral and cannot access host filesystem | low |
| disallow-capabilities | Removed SYS_ADMIN capability addition | Container loses administrative capabilities | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>