### PR TITLE
remediator: Fix policy violations in apps/test/nginx-chart/templates/deployment.yaml

### DIFF
--- a/apps/test/nginx-chart/templates/deployment.yaml
+++ b/apps/test/nginx-chart/templates/deployment.yaml
@@ -18,11 +18,18 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- if .Values.volumes.hostPath.enabled }}
       volumes:
       - name: {{ .Values.volumes.hostPath.name }}
-        hostPath:
-          path: {{ .Values.volumes.hostPath.path }}
+        emptyDir: {}
+      {{- end }}
+      {{- if .Values.volumes.emptyDir.enabled }}
+      volumes:
+      - name: {{ .Values.volumes.emptyDir.name }}
+        emptyDir: {}
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
@@ -35,6 +42,11 @@ spec:
           {{- end }}
         securityContext:
           privileged: {{ .Values.securityContext.privileged }}
+          allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+          runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          seccompProfile:
+            {{- toYaml .Values.securityContext.seccompProfile | nindent 12 }}
           {{- if .Values.securityContext.capabilities }}
           capabilities:
             {{- toYaml .Values.securityContext.capabilities | nindent 12 }}
@@ -43,6 +55,11 @@ spec:
         volumeMounts:
         - name: {{ .Values.volumes.hostPath.name }}
           mountPath: /mnt/host-vol
+        {{- end }}
+        {{- if .Values.volumes.emptyDir.enabled }}
+        volumeMounts:
+        - name: {{ .Values.volumes.emptyDir.name }}
+          mountPath: /mnt/empty-vol
         {{- end }}
         {{- with .Values.resources }}
         resources:

--- a/apps/test/nginx-chart/values.yaml
+++ b/apps/test/nginx-chart/values.yaml
@@ -21,14 +21,19 @@ service:
 
 # Security context settings
 securityContext:
-  privileged: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1001
   capabilities:
-    add:
-      - SYS_ADMIN
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 # Container port configuration
 containerPort: 81
-hostPort: 81
+hostPort: 0
 
 # Volume configuration
 volumes:
@@ -36,10 +41,23 @@ volumes:
     enabled: true
     path: /etc
     name: host-vol
+  emptyDir:
+    enabled: true
+    name: host-vol
 
 # Pod annotations
 podAnnotations:
-  container.apparmor.security.beta.kubernetes.io/nginx-chart: unconfined
+  container.apparmor.security.beta.kubernetes.io/nginx-chart: runtime/default
+
+# Pod security settings
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+# Service account token mounting
+automountServiceAccountToken: false
 
 # Resource limits and requests
 resources: {}


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx-helm

**File:** apps/test/nginx-chart/templates/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-host-ports | Changed hostPort from 81 to 0 (disabled) | Removes direct host port binding, may require service/ingress changes for external access | high |
| disallow-privileged-containers | Changed privileged from true to false | Disables privileged mode, may break functionality requiring host system access | low |
| disallow-host-path | Added emptyDir volume configuration as replacement for hostPath | Volume no longer accesses host filesystem, data will be ephemeral and container-local | low |
| restrict-volume-types | Added emptyDir volume type as allowed alternative to hostPath | Volume storage becomes ephemeral, data will not persist across pod restarts | low |
| disallow-capabilities-strict | Added capability dropping ALL and removed non-allowed capability additions | Container security hardened but may break apps requiring specific capabilities | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Prevents privilege escalation, may affect apps that need elevated permissions | high |
| restrict-apparmor-profiles | Changed AppArmor annotation from 'unconfined' to 'runtime/default' | Applies default AppArmor restrictions, may block certain system calls | high |
| require-run-as-nonroot | Added runAsNonRoot: true and runAsUser: 1001 at both pod and container level | Container runs as non-root user, may break apps expecting root access or specific file permissions | low |
| disallow-capabilities | Changed capabilities from adding SYS_ADMIN to dropping ALL capabilities | Container will run with minimal capabilities, may break functionality requiring elevated privileges | low |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to disable service account token mounting | Disables automatic service account token mounting, breaks apps needing Kubernetes API access | high |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault at pod and container level | Applies default seccomp profile restrictions, may block certain system calls | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>