### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,20 @@ spec:
       labels:
         app: nginx
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +38,12 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| restrict-volume-types | Replaced hostPath volume type with allowed emptyDir volume type | Volume will be empty temporary directory instead of host /etc; application will lose access to host configuration files | low |
| disallow-capabilities | Removed forbidden SYS_ADMIN capability from container capabilities.add section | Application will lose administrative privileges; if the nginx container requires system administration capabilities, it will fail to perform those operations | low |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added 'drop: ALL' to meet strict capability requirements | Container will run with no capabilities; nginx should work normally as it doesn't require special capabilities for basic web serving | high |
| disallow-host-path | Replaced hostPath volume with emptyDir to eliminate host filesystem access | Application will lose access to host /etc directory; if nginx configuration depends on host files, it will fail to start or serve content properly | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container securityContext | Container cannot escalate privileges during runtime; nginx typically doesn't need privilege escalation so should run normally | high |
| disallow-privileged-containers | Changed privileged: true to privileged: false in container securityContext | Container loses privileged access to host resources; if nginx requires privileged operations, it will fail to perform them | low |
| disallow-host-ports | Removed hostPort: 80 from container port configuration | Container port 80 will not be directly accessible from host network; external access will require a Service or Ingress configuration | high |
| restrict-automount-sa-token | Added automountServiceAccountToken: false to pod spec | Pod cannot access Kubernetes API using service account tokens; if nginx needs to communicate with K8s API, it will fail | high |
| restrict-seccomp-strict | Added seccompProfile with type: RuntimeDefault to both pod and container securityContext | Container will run with default seccomp profile restricting system calls; nginx should work normally as it uses common system calls | high |
| require-run-as-nonroot | Added runAsNonRoot: true and runAsUser: 1000 to both pod and container securityContext | Container will run as non-root user; nginx may fail if it requires root privileges for binding to privileged ports or accessing root-owned files | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>