### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,10 +16,12 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
@@ -38,3 +40,5 @@ spec:
           capabilities:
             add:
             - SYS_ADMIN
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** Unknown

**Namespace:** Unknown

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| restrict-volume-types | Replaced hostPath volume with emptyDir to comply with allowed volume types, removing access to host filesystem at /etc | Application will lose access to host /etc directory; if nginx configuration depends on files from host /etc, the application will fail to start | low |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault to both pod-level and container-level securityContext to enforce secure system call filtering | Application behavior should remain normal as RuntimeDefault seccomp profile allows most common system calls; very low risk of breaking functionality | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot splitpr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

</details>