### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,18 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +36,10 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** Unknown

**Namespace:** Unknown

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-capabilities | Removed SYS_ADMIN capability as it's not in the allowed capabilities list | Same as strict capabilities policy - loss of system administration privileges may break specific functionality | low |
| disallow-privileged-containers | Removed privileged: true from container security context | Container loses all privileged access to host resources; may break applications requiring direct hardware access or kernel capabilities | low |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added capabilities.drop: [ALL] to comply with strict capability requirements | Application will lose SYS_ADMIN privileges which could break functionality requiring system administration capabilities like mounting filesystems or managing namespaces | low |
| disallow-host-path | Replaced hostPath volume with emptyDir to prevent access to host filesystem | Application will lose access to host /etc directory; if nginx configuration or certificates are read from host /etc, the application will fail to start | low |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Prevents privilege escalation via setuid/setgid; most applications unaffected unless they specifically need privilege escalation | high |
| restrict-seccomp-strict | Added seccompProfile.type: RuntimeDefault at both pod and container security context level | Runtime will apply default seccomp profile, potentially blocking some system calls; most applications continue running normally | high |
| restrict-volume-types | Replaced hostPath volume type with emptyDir which is in the allowed volume types list | Same as hostPath policy - application loses access to host filesystem data previously available in /etc | low |
| disallow-host-ports | Removed hostPort: 80 to prevent binding to host network port | Application will no longer be directly accessible on host port 80; requires Service or Ingress for external access | high |
| require-run-as-nonroot | Added runAsNonRoot: true at both pod and container security context level | Container will run as non-root user; nginx may fail to bind to port 80 or access files requiring root permissions without proper configuration | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot split-pr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

- `@nirmatabot request-exception <policy-name1> [<policy-name2> ...] [duration] [reason]`

  Request a Policy Exception in Nirmata Control Hub (NCH) for one or more policies.
  The excepted policies are removed from this PR and a Policy Exception Request is created in NCH pending approval.
  Once approved, NCH generates a `PolicyException` manifest scoped to this exact resource and opens a new PR.

  | Argument | Required | Description |
  |---|---|---|
  | `policy-name` | Yes | One or more Kyverno policy names to request an exception for |
  | `duration` | No | How long the exception should last: a number of days (e.g. `7d`, `30d`) or `permanent` for no expiry. Defaults to permanent if omitted. |
  | `reason` | No | Free-text justification for the exception request (all text after the duration token). Shown in the NCH approval UI. |

  **Examples:**
  ```
  @nirmatabot request-exception disallow-capabilities-strict
  @nirmatabot request-exception disallow-capabilities-strict 30d
  @nirmatabot request-exception disallow-capabilities-strict 30d Required for legacy workload migration
  @nirmatabot request-exception disallow-host-ports restrict-apparmor-profiles 7d Approved by security team
  ```

</details>