### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -18,14 +18,12 @@ spec:
     spec:
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +32,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** Unknown

**Namespace:** Unknown

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-privileged-containers | Changed privileged: true to privileged: false in container security context | Container loses unrestricted host access and elevated kernel capabilities; may break if nginx requires privileged operations | low |
| restrict-seccomp-strict | Added seccompProfile with RuntimeDefault type to container security context | Container uses default seccomp profile restricting system calls; minimal impact for typical nginx workloads | high |
| restrict-volume-types | Replaced hostPath volume with emptyDir volume type | Application loses access to host /etc directory; will break if nginx configuration depends on host files in /etc | low |
| require-run-as-nonroot | Added runAsNonRoot: true to container security context | Container must run as non-root user; nginx may fail if it needs root privileges for port binding or file access | low |
| disallow-capabilities | Removed disallowed SYS_ADMIN capability from container security context | Application will lose system admin privileges; if the nginx container requires elevated system capabilities, it may fail to perform certain operations | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Container cannot escalate privileges at runtime; minimal impact for typical nginx workloads | high |
| disallow-host-path | Replaced hostPath volume mount with emptyDir volume | Same as restrict-volume-types - application loses access to host /etc directory | low |
| disallow-host-ports | Removed hostPort mapping from container port configuration | Application will no longer be accessible directly on host port 80; requires LoadBalancer or NodePort service for external access | high |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added drop ALL capabilities requirement | Container drops all Linux capabilities; may impact nginx if it requires specific capabilities for operation | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot split-pr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

- `@nirmatabot request-exception <policy-name1> [<policy-name2> ...] [duration] [reason]`

  Request a Policy Exception in Nirmata Control Hub (NCH) for one or more policies.
  The excepted policies are removed from this PR and a Policy Exception Request is created in NCH pending approval.
  Once approved, NCH generates a `PolicyException` manifest scoped to this exact resource and opens a new PR.

  | Argument | Required | Description |
  |---|---|---|
  | `policy-name` | Yes | One or more Kyverno policy names to request an exception for |
  | `duration` | No | How long the exception should last: a number of days (e.g. `7d`, `30d`) or `permanent` for no expiry. Defaults to permanent if omitted. |
  | `reason` | No | Free-text justification for the exception request (all text after the duration token). Shown in the NCH approval UI. |

  **Examples:**
  ```
  @nirmatabot request-exception disallow-capabilities-strict
  @nirmatabot request-exception disallow-capabilities-strict 30d
  @nirmatabot request-exception disallow-capabilities-strict 30d Required for legacy workload migration
  @nirmatabot request-exception disallow-host-ports restrict-apparmor-profiles 7d Approved by security team
  ```

</details>