### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,18 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +36,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** Unknown

**Namespace:** Unknown

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container security context | Medium impact - prevents privilege escalation via setuid/setgid binaries; may break applications using such binaries | high |
| disallow-privileged-containers | Changed privileged from true to false in container security context | High impact - privileged mode provides access to host devices and bypasses security mechanisms; disabling will break applications requiring direct hardware access | low |
| disallow-host-path | Replaced hostPath volume with emptyDir volume | High impact - application loses access to host /etc directory; will break if it needs to read host configuration files like /etc/passwd or /etc/ssl/certs | low |
| require-run-as-nonroot | Added runAsNonRoot: true to pod and container security contexts | High impact - container must run as non-root user; will fail if application or image requires root privileges or doesn't specify a non-root user | low |
| restrict-volume-types | Replaced hostPath volume with emptyDir volume type | High impact - application loses access to host filesystem /etc directory; will fail if it requires reading host configuration files | low |
| disallow-capabilities | Removed disallowed SYS_ADMIN capability from container capabilities.add | High impact - SYS_ADMIN provides extensive system privileges; removing it will break applications requiring advanced system operations like mounting filesystems or network configuration | low |
| disallow-host-ports | Removed hostPort 80 binding from container port configuration | Medium impact - application will no longer be directly accessible on host port 80; requires Service/Ingress for external access | high |
| restrict-seccomp-strict | Added seccomp profile type RuntimeDefault to pod and container security contexts | Minimal impact - seccomp profile adds system call filtering which is transparent to most applications | high |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added required ALL capability drop | High impact - dropping ALL capabilities removes all Linux capabilities from the container; applications requiring any special privileges will fail | low |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot split-pr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

- `@nirmatabot request-exception <policy-name1> [<policy-name2> ...] [duration] [reason]`

  Request a Policy Exception in Nirmata Control Hub (NCH) for one or more policies.
  The excepted policies are removed from this PR and a Policy Exception Request is created in NCH pending approval.
  Once approved, NCH generates a `PolicyException` manifest scoped to this exact resource and opens a new PR.

  | Argument | Required | Description |
  |---|---|---|
  | `policy-name` | Yes | One or more Kyverno policy names to request an exception for |
  | `duration` | No | How long the exception should last: a number of days (e.g. `7d`, `30d`) or `permanent` for no expiry. Defaults to permanent if omitted. |
  | `reason` | No | Free-text justification for the exception request (all text after the duration token). Shown in the NCH approval UI. |

  **Examples:**
  ```
  @nirmatabot request-exception disallow-capabilities-strict
  @nirmatabot request-exception disallow-capabilities-strict 30d
  @nirmatabot request-exception disallow-capabilities-strict 30d Required for legacy workload migration
  @nirmatabot request-exception disallow-host-ports restrict-apparmor-profiles 7d Approved by security team
  ```

</details>