### PR TITLE
remediator: Fix policy violations in apps/nginx/deployment.yaml

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -16,16 +16,18 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: host-vol
-        hostPath:
-          path: /etc
+        emptyDir: {}
       containers:
       - name: nginx
         image: nginx:latest
         ports:
         - containerPort: 80
-          hostPort: 80
         resources:
           requests:
             memory: "300Mi"
@@ -34,7 +36,11 @@ spec:
             memory: "2800Mi"
             cpu: "5000m"
         securityContext:
-          privileged: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
-            add:
-            - SYS_ADMIN
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** Unknown

**Namespace:** Unknown

**File:** apps/nginx/deployment.yaml

## Remediation Results

| Policy Name | Explanation | Runtime Impact | Confidence |
|-------------|-------------|----------------|------------|
| disallow-capabilities | Removed SYS_ADMIN capability from container securityContext as it's not in the allowed capabilities list. | Application loses SYS_ADMIN capability which provides extensive system administration privileges; if the app needs to mount filesystems, modify kernel parameters, or perform other admin tasks, it will fail. | low |
| disallow-capabilities-strict | Removed SYS_ADMIN capability and added 'drop: [ALL]' to container securityContext to comply with strict capability restrictions. | Application loses all capabilities including SYS_ADMIN and any default capabilities; if the app needs any Linux capabilities for network binding, file operations, or system calls, it will fail. | low |
| disallow-host-path | Replaced hostPath volume with emptyDir to eliminate host filesystem access. | Application loses access to host directory /etc; if the app depends on host configuration files, SSL certificates, or system information from /etc, it will fail to access required data. | low |
| restrict-seccomp-strict | Added seccompProfile with type RuntimeDefault to both pod and container securityContext to enforce secure system call filtering. | Application syscalls will be filtered by default seccomp profile; if the app uses non-standard syscalls, it may fail or behave unexpectedly. | high |
| disallow-privileged-containers | Changed privileged from true to false in container securityContext to remove privileged access. | Application loses all privileged capabilities and host access; if the app requires low-level system access, device access, or kernel modules, it will fail to function properly. | low |
| restrict-volume-types | Replaced hostPath volume 'host-vol' with emptyDir to use only allowed volume types. | Application loses access to host directory /etc; if the app reads configuration files, certificates, or other data from /etc, it will fail to function properly. | low |
| require-run-as-nonroot | Added runAsNonRoot: true to both pod and container securityContext to enforce non-root execution. | Application must run as non-root user; if the container image defaults to root or the app requires root privileges for file access, port binding, or system operations, it will fail to start. | low |
| disallow-host-ports | Removed hostPort: 80 from container port configuration to prevent host network exposure. | Application will lose ability to bind to host port 80; if external access to port 80 is required, use a Service with LoadBalancer or NodePort type instead. | high |
| disallow-privilege-escalation | Added allowPrivilegeEscalation: false to container securityContext to prevent privilege escalation. | Application cannot escalate privileges during runtime; if the app uses setuid/setgid binaries or needs to change user context, it will fail. | high |


---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot split-pr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

- `@nirmatabot request-exception <policy-name1> [<policy-name2> ...] [duration] [reason]`

  Request a Policy Exception in Nirmata Control Hub (NCH) for one or more policies.
  The excepted policies are removed from this PR and a Policy Exception Request is created in NCH pending approval.
  Once approved, NCH generates a `PolicyException` manifest scoped to this exact resource and opens a new PR.

  | Argument | Required | Description |
  |---|---|---|
  | `policy-name` | Yes | One or more Kyverno policy names to request an exception for |
  | `duration` | No | How long the exception should last: a number of days (e.g. `7d`, `30d`) or `permanent` for no expiry. Defaults to permanent if omitted. |
  | `reason` | No | Free-text justification for the exception request (all text after the duration token). Shown in the NCH approval UI. |

  **Examples:**
  ```
  @nirmatabot request-exception disallow-capabilities-strict
  @nirmatabot request-exception disallow-capabilities-strict 30d
  @nirmatabot request-exception disallow-capabilities-strict 30d Required for legacy workload migration
  @nirmatabot request-exception disallow-host-ports restrict-apparmor-profiles 7d Approved by security team
  ```

</details>