### PR TITLE
fix(resources): Right-size %s via VPA recommendations

### DIFF
--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -19,24 +19,24 @@ spec:
         app: nginx
     spec:
       volumes:
-      - name: host-vol
-        hostPath:
-          path: /etc
+        - name: host-vol
+          hostPath:
+            path: /etc
       containers:
-      - name: nginx
-        image: nginx:latest
-        ports:
-        - containerPort: 80
-          hostPort: 80
-        resources:
-          requests:
-            memory: "300Mi"
-            cpu: "500m"
-          limits:
-            memory: "2800Mi"
-            cpu: "5000m"
-        securityContext:
-          privileged: true
-          capabilities:
-            add:
-            - SYS_ADMIN
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+              hostPort: 80
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "2800Mi"
+              cpu: "5000m"
+          securityContext:
+            privileged: true
+            capabilities:
+              add:
+                - SYS_ADMIN


### PR DESCRIPTION
## Policy Violation Remediation

**Cluster:** remediator-host

**Namespace:** nginx

**File:** apps/nginx/deployment.yaml

## Remediation Results

_No policy explanations available._

---

<details>
<summary><strong>Nirmatabot commands and options</strong></summary>

You can trigger nirmatabot actions by commenting on this PR:

- `@nirmatabot split-pr <policy-name1> <policy-name2> ...` – Split a multi-policy remediation PR into separate, independent PRs.

- `@nirmatabot request-exception <policy-name1> [<policy-name2> ...] [duration] [reason]`

  Request a Policy Exception in Nirmata Control Hub (NCH) for one or more policies.
  The excepted policies are removed from this PR and a Policy Exception Request is created in NCH pending approval.
  Once approved, NCH generates a `PolicyException` manifest scoped to this exact resource and opens a new PR.

  | Argument | Required | Description |
  |---|---|---|
  | `policy-name` | Yes | One or more Kyverno policy names to request an exception for |
  | `duration` | No | How long the exception should last: a number of days (e.g. `7d`, `30d`) or `permanent` for no expiry. Defaults to permanent if omitted. |
  | `reason` | No | Free-text justification for the exception request (all text after the duration token). Shown in the NCH approval UI. |

  **Examples:**
  ```
  @nirmatabot request-exception disallow-capabilities-strict
  @nirmatabot request-exception disallow-capabilities-strict 30d
  @nirmatabot request-exception disallow-capabilities-strict 30d Required for legacy workload migration
  @nirmatabot request-exception disallow-host-ports restrict-apparmor-profiles 7d Approved by security team
  ```

</details>